### PR TITLE
jsonなのでキーにダブルクォテーションが必要？

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -3,7 +3,7 @@
   "rules": {
     "preset-ja-technical-writing": {
       "sentence-length": {
-        max: 90
+        "max": 90
       },
       "arabic-kanji-numbers": true,
       "ja-no-weak-phrase": false,


### PR DESCRIPTION
公式でそうなっていたのと手元に持ってきたらエラー出たので
https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing#%E3%83%AB%E3%83%BC%E3%83%AB%E3%81%AE%E8%A8%AD%E5%AE%9A%E6%96%B9%E6%B3%95